### PR TITLE
Fuzzer

### DIFF
--- a/catris.py
+++ b/catris.py
@@ -1470,7 +1470,6 @@ class Client:
         self.writer.write(to_send)
 
     async def _receive_bytes(self) -> bytes | None:
-        # TODO: is the error handling needed?
         try:
             await asyncio.sleep(0)  # Makes game playable while fuzzer is running
             result = await self._reader.read(10)

--- a/catris.py
+++ b/catris.py
@@ -1484,7 +1484,10 @@ class Client:
 
             # \r moves cursor to start of line
             self.writer.write(b"\r" + CLEAR_FROM_CURSOR_TO_END_OF_SCREEN + SHOW_CURSOR)
-            await self.writer.drain()
+            try:
+                await self.writer.drain()
+            except OSError:
+                pass
             self.writer.close()
 
 

--- a/catris.py
+++ b/catris.py
@@ -1470,8 +1470,8 @@ class Client:
         self.writer.write(to_send)
 
     async def _receive_bytes(self) -> bytes | None:
+        await asyncio.sleep(0)  # Makes game playable while fuzzer is running
         try:
-            await asyncio.sleep(0)  # Makes game playable while fuzzer is running
             result = await self._reader.read(10)
         except OSError as e:
             print("Receive error:", self.name, e)

--- a/catris.py
+++ b/catris.py
@@ -1488,18 +1488,12 @@ class Client:
             self.writer.close()
 
 
-async def bloop() -> None:
-    while True:
-        print("bloop")
-        await asyncio.sleep(1)
-
-
 async def main() -> None:
     my_server = Server()
     asyncio_server = await asyncio.start_server(my_server.handle_connection, port=12345)
     async with asyncio_server:
         print("Listening on port 12345...")
-        await asyncio.gather(asyncio_server.serve_forever(), bloop(), *my_server.tasks)
+        await asyncio.gather(asyncio_server.serve_forever(), *my_server.tasks)
 
 
 asyncio.run(main())

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -14,6 +14,9 @@ commands = [
     b"a",
     b"s",
     b"d",
+    b"f",
+    b"x",
+    b"hello world :)",
 ]
 conn = socket.create_connection(("localhost", 12345))
 while True:

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -1,0 +1,20 @@
+import random
+import socket
+
+commands = [
+    b"\x08",
+    b"\x7f",
+    b"\x1b[A",
+    b"\x1b[B",
+    b"\x1b[C",
+    b"\x1b[D",
+    b"\r",
+    b"\n",
+    b"w",
+    b"a",
+    b"s",
+    b"d",
+]
+conn = socket.create_connection(("localhost", 12345))
+while True:
+    conn.send(random.choice(commands))


### PR DESCRIPTION
Fixes #33 and a couple other subtle bugs.

Remaining bugs that I should make issues for:
- 100% CPU usage while fuzzer is running. This could be a ddos over network, if someone simply runs fuzzer against online server. Game still kinda playable if you join while fuzzer running.
- Sometimes it gets to a state where no clients connected but terminal repeatedly prints `socket.send() raised exception.` I wonder why asyncio's internals print this, so weird...
- If I stop fuzzer with ctrl+z, the game still appears to be running, presumably because asyncio creates an insanely huge input buffer.