### PR TITLE
cleanup: get rid of MovingBlock.player

### DIFF
--- a/catris/games/bottle.py
+++ b/catris/games/bottle.py
@@ -58,7 +58,7 @@ class BottleGame(Game):
     def is_valid(self) -> bool:
         return super().is_valid() and all(
             (square.x, max(0, square.y)) in self.valid_landed_coordinates
-            for block in self._get_moving_blocks()
+            for block in self._get_moving_blocks().values()
             for square in block.squares
         )
 

--- a/catris/games/ring.py
+++ b/catris/games/ring.py
@@ -125,12 +125,12 @@ class RingGame(Game):
         if not super().is_valid():
             return False
 
-        for block in self._get_moving_blocks():
+        for player, block in self._get_moving_blocks().items():
             for square in block.squares:
                 if max(abs(square.x), abs(square.y)) <= self.MIDDLE_AREA_RADIUS:
                     # print("Invalid state: moving block inside middle area")
                     return False
-                player_x, player_y = block.player.world_to_player(square.x, square.y)
+                player_x, player_y = player.world_to_player(square.x, square.y)
                 if player_x < -self.GAME_RADIUS or player_x > self.GAME_RADIUS:
                     # print("Invalid state: moving block out of horizontal bounds")
                     return False

--- a/catris/games/traditional.py
+++ b/catris/games/traditional.py
@@ -68,7 +68,7 @@ class TraditionalGame(Game):
 
         return super().is_valid() and all(
             square.x in range(self._get_width()) and square.y < self.HEIGHT
-            for block in self._get_moving_blocks()
+            for block in self._get_moving_blocks().values()
             for square in block.squares
         )
 

--- a/catris/player.py
+++ b/catris/player.py
@@ -7,7 +7,6 @@ from catris.squares import Square, create_moving_squares
 
 @dataclasses.dataclass(eq=False)
 class MovingBlock:
-    player: Player
     squares: set[Square]
     fast_down: bool = False
 


### PR DESCRIPTION
It doesn't make sense for MovingBlock to have a player, because a Player already has a MovingBlock.