### PR TITLE
add dark text color to (you)

### DIFF
--- a/catris/views.py
+++ b/catris/views.py
@@ -314,7 +314,7 @@ class ChooseGameView(MenuView):
                 + (COLOR % 0)
             )
             if client == self._client:
-                text += b" (you)"
+                text += (COLOR % 90) + b" (you)" + (COLOR % 0)
             result.append(text)
         result.extend([b""] * (MAX_CLIENTS_PER_LOBBY - len(self._client.lobby.clients)))
         result.extend(super().get_lines_to_render())


### PR DESCRIPTION
This seems to be consistent with what other UIs are doing: if there's some extra info that you might not be interested in, just show it in gray.

Tested on putty (works), linux terminal (works), and windows cmd (shows `(you)` in white just like before).