### PR TITLE
hide/show lobby id by pressing h

### DIFF
--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -58,7 +58,16 @@ class Client:
         self.lobby: Lobby | None = None
         self.color: int | None = None
         self.view: View = AskNameView(self)
+
         self.rotate_counter_clockwise = False
+        self.lobby_id_hidden = False
+
+    def get_lobby_id_for_display(self) -> bytes:
+        if self.lobby is None:
+            return b""
+        if self.lobby_id_hidden:
+            return b"Lobby ID: ******"
+        return f"Lobby ID: {self.lobby.lobby_id}".encode("ascii")
 
     def log(self, msg: str, *, level: int = logging.INFO) -> None:
         logging.log(level, f"(client {self._client_id}) {msg}")

--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -63,7 +63,8 @@ class Client:
         self.lobby_id_hidden = False
 
     def get_lobby_id_for_display(self) -> bytes:
-        if self.lobby is None:
+        assert self.lobby is not None
+        if self.lobby.lobby_id is None:
             return b""
         if self.lobby_id_hidden:
             return b"Lobby ID: ******"

--- a/catris/views.py
+++ b/catris/views.py
@@ -298,7 +298,17 @@ class ChooseGameView(MenuView):
         result = [b"", b""]
         if self._client.server.only_lobby is None:
             # Multiple lobbies mode
-            result.append(f"   Lobby ID: {self._client.lobby.lobby_id}".encode("ascii"))
+            if self._client.lobby_id_hidden:
+                h_message = b" (press h to show)"
+            else:
+                h_message = b" (press h to hide)"
+            result.append(
+                b"   "
+                + self._client.get_lobby_id_for_display()
+                + (COLOR % 90)
+                + h_message
+                + (COLOR % 0)
+            )
             result.append(b"")
             result.append(b"   Players in lobby:")
         else:
@@ -325,6 +335,12 @@ class ChooseGameView(MenuView):
                 (COLOR % 31) + b"This game is full.".center(80).rstrip() + (COLOR % 0)
             )
         return result
+
+    def handle_key_press(self, received: bytes) -> bool:
+        if received in (b"H", b"h"):
+            self._client.lobby_id_hidden = not self._client.lobby_id_hidden
+            return False
+        return super().handle_key_press(received)
 
     def on_enter_pressed(self) -> bool:
         if self.menu_items[self.selected_index] == "Quit":
@@ -459,9 +475,7 @@ class PlayingView(View):
     def get_lines_to_render(self) -> list[bytes]:
         lines = self.game.get_lines_to_render(self.player)
         assert self._client.lobby is not None
-        if self._client.lobby.lobby_id is not None:
-            # multiple lobbies mode
-            lines[4] += f"  Lobby ID: {self._client.lobby.lobby_id}".encode("ascii")
+        lines[4] += b"  " + self._client.get_lobby_id_for_display()
         lines[5] += (
             (COLOR % 36) + f"  Score: {self.game.score}".encode("ascii") + (COLOR % 0)
         )


### PR DESCRIPTION
I think it's *very* unlikely that anyone will ever stream a game of catris to an audience of more than 3 people, but in case that ever happens, they can now prevent the audience from joining the game.

Fixes #96 
Uses same colors as #102 