### PR TITLE
Several fixes to disconnecting when send queue fills up

### DIFF
--- a/catris.service
+++ b/catris.service
@@ -11,7 +11,7 @@
 Description=catris
 
 [Service]
-ExecStart=/usr/bin/python3 -u -m catris --lobbies
+ExecStart=/usr/bin/python3 -m catris --lobbies
 
 # adduser --system catris
 WorkingDirectory=/home/catris

--- a/catris.service
+++ b/catris.service
@@ -11,7 +11,7 @@
 Description=catris
 
 [Service]
-ExecStart=/usr/bin/python3 -m catris --lobbies
+ExecStart=/usr/bin/python3 -u -m catris --lobbies
 
 # adduser --system catris
 WorkingDirectory=/home/catris

--- a/catris/games/game_base_class.py
+++ b/catris/games/game_base_class.py
@@ -473,6 +473,7 @@ class Game:
                     player, dx=0, dy=1, in_player_coords=True, can_drill=True
                 )
                 if moved:
+                    self.need_render_event.set()
                     something_moved = True
                     todo.remove(player)
             if not something_moved:
@@ -496,9 +497,9 @@ class Game:
         async with self.flashing_lock:
             full_lines_iter = self.find_and_then_wipe_full_lines()
             full_squares = next(full_lines_iter)
-            self.need_render_event.set()
 
             if full_squares:
+                self.need_render_event.set()
                 await self.flash({(s.x, s.y) for s in full_squares}, 47)
                 try:
                     # run past yield, which deletes points
@@ -507,8 +508,7 @@ class Game:
                     # This means function ended without a second yield.
                     # It's expected, and in fact happens every time.
                     pass
-
-            self.need_render_event.set()
+                self.need_render_event.set()
 
     async def _move_blocks_down_task(self, fast: bool) -> None:
         while True:

--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -147,6 +147,9 @@ class Client:
         self._send_bytes(to_send)
 
     def _send_bytes(self, b: bytes) -> None:
+        if self.writer.transport.is_closing():
+            return
+
         self.writer.write(b)
 
         # Prevent filling the server's memory if client sends but never receives.

--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -67,6 +67,7 @@ class Client:
         self.server = server
         self._reader = reader
         self.writer = writer
+        self._current_receive_task: asyncio.Task[bytes] | None = None
         self._recv_stats: collections.deque[tuple[float, int]] = collections.deque()
 
         self.name: str | None = None
@@ -157,6 +158,9 @@ class Client:
         if self.writer.transport.get_write_buffer_size() > 64 * 1024:  # type: ignore
             self.log("More than 64K of data in send buffer, disconnecting")
             self.writer.transport.close()
+            # Closing isn't enough to stop receiving immediately
+            if self._current_receive_task is not None:
+                self._current_receive_task.cancel()
 
     async def _receive_bytes(self) -> bytes | None:
         # Makes game playable while under very heavy cpu load.
@@ -166,8 +170,10 @@ class Client:
         if self.writer.transport.is_closing():
             return None
 
+        assert self._current_receive_task is None
+        self._current_receive_task = asyncio.create_task(self._reader.read(100))
         try:
-            result = await asyncio.wait_for(self._reader.read(100), timeout=3 * 60)
+            result = await asyncio.wait_for(self._current_receive_task, timeout=3 * 60)
         except asyncio.TimeoutError:
             self.log("Nothing received in 3min, disconnecting")
             self._send_bytes(
@@ -178,6 +184,8 @@ class Client:
         except OSError as e:
             self.log(f"Receive error: {e}")
             return None
+        finally:
+            self._current_receive_task = None
 
         # Prevent 100% cpu usage if someone sends a lot of data
         now = time.monotonic()

--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -185,6 +185,9 @@ class Client:
                 + b"Closing connection because it has been idle for 3 minutes.\r\n"
             )
             return None
+        except asyncio.CancelledError:
+            # cancelled in _send_bytes()
+            return None
         except OSError as e:
             self.log(f"Receive error: {e}")
             return None


### PR DESCRIPTION
There were several problems:
- The game was rendering 40 times per second. That's how fast the blocks move after pressing down arrow key. But it was rendering that much even if no blocks were in fast-down mode...
- The log message appeared many times.
- When the log message appeared, it didn't actually disconnect immediately, because closing the transport doesn't stop receiving. Instead you have to make a task that receives and cancel that.

Also, max buffer size was 64K, ridiculously big. It's now 4K. It could be 0 and it would still work, because linux has its own buffering which is much bigger than this buffer anyway, but I'm not sure how other operating systems do it.

I decided to not add `-u`, because python's `logging` module flushes stderr after printing each line.

Fixes #128 