### PR TITLE
Change idle time from 3min to 10min

### DIFF
--- a/catris.service
+++ b/catris.service
@@ -5,7 +5,10 @@
 #    systemctl status catris
 #    journalctl -fu catris
 #
-# Logs should go to /var/log/syslog
+# Also add to end of /etc/sysctl.conf:
+#
+#    net.ipv4.tcp_keepalive_time = 180
+#    net.ipv4.tcp_keepalive_intvl = 180
 
 [Unit]
 Description=catris

--- a/catris/__main__.py
+++ b/catris/__main__.py
@@ -23,7 +23,7 @@ async def main() -> None:
     )
 
     # Send TCP keepalive packets periodically as configured in /etc/sysctl.conf
-    # Prevents things from disconnecting by itself.
+    # Prevents clients from disconnecting after about 5 minutes of inactivity.
     for sock in asyncio_server.sockets:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 

--- a/catris/__main__.py
+++ b/catris/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import logging
+import socket
 
 from catris.server_and_client import Server
 
@@ -20,6 +21,12 @@ async def main() -> None:
     asyncio_server = await asyncio.start_server(
         catris_server.handle_connection, port=12345
     )
+
+    # Send TCP keepalive packets periodically as configured in /etc/sysctl.conf
+    # Prevents things from disconnecting by itself.
+    for sock in asyncio_server.sockets:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
     async with asyncio_server:
         logging.info("Listening on port 12345...")
         await asyncio_server.serve_forever()

--- a/catris/server_and_client.py
+++ b/catris/server_and_client.py
@@ -177,12 +177,12 @@ class Client:
         assert self._current_receive_task is None
         self._current_receive_task = asyncio.create_task(self._reader.read(100))
         try:
-            result = await asyncio.wait_for(self._current_receive_task, timeout=3 * 60)
+            result = await asyncio.wait_for(self._current_receive_task, timeout=10 * 60)
         except asyncio.TimeoutError:
-            self.log("Nothing received in 3min, disconnecting")
+            self.log("Nothing received in 10min, disconnecting")
             self._send_bytes(
                 SHOW_CURSOR
-                + b"Closing connection because it has been idle for 3 minutes.\r\n"
+                + b"Closing connection because it has been idle for 10 minutes.\r\n"
             )
             return None
         except asyncio.CancelledError:


### PR DESCRIPTION
This was trickier than expected, because something with linode closes the connection after about 5 minutes of idling, so I had to configure tcp keepalive to work around that. I have tested each individual change, but I don't have a good way to test whether it all works together properly.

Fixes #141 