### PR TITLE
Fix time formatting for games longer than 1h

### DIFF
--- a/catris/high_scores.py
+++ b/catris/high_scores.py
@@ -43,7 +43,7 @@ class HighScore:
         hours = minutes // 60
 
         if hours:
-            return f"{hours}h"
+            return f"{hours}h {minutes - 60*hours}min"
         if minutes:
             return f"{minutes}min"
         return f"{seconds}sec"


### PR DESCRIPTION
When testing #162 I ended up playing a really good ring game, and the time showed up as `1h`. I was wondering whether that means 1 hour exactly. It now shows up as `1h 4min`.