### PR TITLE
Speed up game exponentially, instead of linear

### DIFF
--- a/catris/games/game_base_class.py
+++ b/catris/games/game_base_class.py
@@ -507,6 +507,6 @@ class Game:
             else:
                 # I tried blocks_per_second = ax+b, where x is duration.
                 # Games ended slowly, blocks coming fast and not much happening.
-                blocks_per_second = 2 * 1.07**(self.get_duration_sec() / 60)
+                blocks_per_second = 2 * 1.07 ** (self.get_duration_sec() / 60)
                 await self.pause_aware_sleep(1 / blocks_per_second)
             await self._move_blocks_down_once(fast)

--- a/catris/games/game_base_class.py
+++ b/catris/games/game_base_class.py
@@ -505,5 +505,8 @@ class Game:
             if fast:
                 await self.pause_aware_sleep(0.025)
             else:
-                await self.pause_aware_sleep(0.5 / (1 + self.get_duration_sec() / 600))
+                # I tried blocks_per_second = ax+b, where x is duration.
+                # Games ended slowly, blocks coming fast and not much happening.
+                blocks_per_second = 2 * 1.07**(self.get_duration_sec() / 60)
+                await self.pause_aware_sleep(1 / blocks_per_second)
             await self._move_blocks_down_once(fast)


### PR DESCRIPTION
When a game ends, the game is usually too fast for players to do anything, but slow enough to keep the game going. This means that score doesn't increment for a very long time, sometimes so long that a player intentionally stops the game.

Below:
- x axis is game duration in minutes
- y axis is blocks per second
- red line is before this PR
- blue curve is after this PR

![Nimetön](https://user-images.githubusercontent.com/18505570/168447652-6f0364cf-0a02-476a-a4f3-a4b2fe6966d9.png)

