### PR TITLE
Prevent unnecessary line of logging when websocket closes

### DIFF
--- a/catris/connections.py
+++ b/catris/connections.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 
 try:
-    from websockets.exceptions import WebSocketException
+    from websockets.exceptions import ConnectionClosedOK, WebSocketException
     from websockets.server import WebSocketServerProtocol
 except ImportError:
+    ConnectionClosedOK = None  # type: ignore
     WebSocketException = None  # type: ignore
     WebSocketServerProtocol = None  # type: ignore
 
@@ -77,6 +78,8 @@ class WebSocketConnection:
     async def receive_bytes(self) -> bytes:
         try:
             result = await self._ws.recv()
+#        except ConnectionClosedOK:
+#            return b""
         except WebSocketException as e:
             raise OSError(str(e)) from e
 

--- a/catris/connections.py
+++ b/catris/connections.py
@@ -78,8 +78,8 @@ class WebSocketConnection:
     async def receive_bytes(self) -> bytes:
         try:
             result = await self._ws.recv()
-#        except ConnectionClosedOK:
-#            return b""
+        except ConnectionClosedOK:
+            return b""
         except WebSocketException as e:
             raise OSError(str(e)) from e
 

--- a/catris/connections.py
+++ b/catris/connections.py
@@ -78,8 +78,8 @@ class WebSocketConnection:
     async def receive_bytes(self) -> bytes:
         try:
             result = await self._ws.recv()
-        except ConnectionClosedOK:
-            return b""
+#        except ConnectionClosedOK:
+#            return b""
         except WebSocketException as e:
             raise OSError(str(e)) from e
 


### PR DESCRIPTION
Before:

```
[INFO] (client 1) Receive error: received 1001 (going away); then sent 1001 (going away)
[INFO] (client 1) Closing connection
[INFO] (client 1) There are now 0 connected clients
```

After:

```
[INFO] (client 1) Closing connection
[INFO] (client 1) There are now 0 connected clients
```