### PR TITLE
restrict name chars

### DIFF
--- a/catris/views.py
+++ b/catris/views.py
@@ -106,7 +106,7 @@ class TextEntryView(View):
 # latin-1 chars, aka bytes(range(256)).decode("latin-1"), with some removed
 # It's important to ban characters that are more than 1 unit wide on terminal.
 VALID_NAME_CHARS = (
-    " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×÷"
+    " !\"#$%&'()*+-./:;<=>?@\\^_`{|}~¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿×÷"
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789"


### PR DESCRIPTION
If you see `[12] foo`, you expect that to mean that a player named `foo` is on their waiting time for 12 more seconds. If you see `foo, bar` in the high scores, you expect that to be two different players, `foo` and `bar`.

To make sure this works as expected, player names shouldn't contain `[`, `]` or `,`