### PR TITLE
Replace "moving block" with less ambiguous "falling block" everywhere

### DIFF
--- a/src/game_logic/test.rs
+++ b/src/game_logic/test.rs
@@ -57,7 +57,7 @@ fn dump_game_state(game: &Game) -> Vec<String> {
             let point = game.players[0].borrow().player_to_world((x, y));
             if !game.is_valid_landed_block_coords(point) {
                 row.push_str("..");
-            } else if game.get_moving_square((x as i16, y as i16), None).is_some() {
+            } else if game.get_falling_square((x as i16, y as i16), None).is_some() {
                 row.push_str("FF");
             } else if game.get_landed_square((x as i16, y as i16)).is_some() {
                 row.push_str("LL");

--- a/src/game_logic/test.rs
+++ b/src/game_logic/test.rs
@@ -57,7 +57,10 @@ fn dump_game_state(game: &Game) -> Vec<String> {
             let point = game.players[0].borrow().player_to_world((x, y));
             if !game.is_valid_landed_block_coords(point) {
                 row.push_str("..");
-            } else if game.get_falling_square((x as i16, y as i16), None).is_some() {
+            } else if game
+                .get_falling_square((x as i16, y as i16), None)
+                .is_some()
+            {
                 row.push_str("FF");
             } else if game.get_landed_square((x as i16, y as i16)).is_some() {
                 row.push_str("LL");

--- a/src/ingame_ui.rs
+++ b/src/ingame_ui.rs
@@ -297,7 +297,7 @@ fn render_blocks(game: &Game, buffer: &mut RenderBuffer, client_id: u64) {
 
     let mut trace_points = game.predict_landing_place(player_idx);
 
-    // Don't trace on top of current player's moving block or flashing
+    // Don't trace on top of flashing or the current player's falling block
     let mut trace_color = Color::DEFAULT;
     {
         let player = game.players[player_idx].borrow();
@@ -334,7 +334,7 @@ fn render_blocks(game: &Game, buffer: &mut RenderBuffer, client_id: u64) {
                     },
                 );
             } else if let Some((content, relative_coords, owner_idx)) =
-                game.get_moving_square(world_point, None)
+                game.get_falling_square(world_point, None)
             {
                 let (moving_x, moving_y) = game.players[owner_idx].borrow().down_direction;
                 content.render(


### PR DESCRIPTION
Fixes #232 