### PR TITLE
web ui: set font-family on terminal-container

### DIFF
--- a/web-ui/style.css
+++ b/web-ui/style.css
@@ -5,6 +5,7 @@ body {
 
 #terminal-container {
   display: grid;
+  font-family: monospace;
 }
 
 #terminal, #cursor-overlay {
@@ -25,6 +26,7 @@ body {
   padding: 0px;
   border: 0px;
   margin: 0px;
+  font-family: inherit;
 }
 
 #cursor-overlay {


### PR DESCRIPTION
This way the whole terminal uses the same font, and `width: 80ch;` or similar set in the javascript code is in the correct units.

Fixes #223 