### PR TITLE
Display ping

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,6 @@ async fn ping_task(render_data_ref: Weak<Mutex<RenderData>>) {
                 continue;
             }
         } else {
-            println!("End Ping Task");
             break;
         }
     }
@@ -136,7 +135,6 @@ impl Client {
                     let mut render_data = self.render_data.lock().unwrap();
                     if let Some(ping_state) = &mut render_data.ping_state {
                         if let Some(ping_sent) = ping_state.sent {
-                            println!("Update Ping!");
                             ping_state.time = Some(ping_sent.elapsed());
                             return Ok(KeyPress::PingResponse); // refresh screen to show new ping time
                         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,7 @@
 use crate::ansi;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 use tokio::sync::Notify;
 
 pub struct RenderBuffer {
@@ -203,6 +205,7 @@ impl RenderBuffer {
         result
     }
 
+    // TODO: should this be called from a method of RenderData?
     pub fn get_updates_as_ansi_codes(
         &self,
         old: &RenderBuffer,
@@ -230,17 +233,35 @@ impl RenderBuffer {
     }
 }
 
+pub struct PingState {
+    pub send_soon: bool,
+    pub sent: Option<Instant>,
+    pub time: Option<Duration>, // this is the value that is shown in UI
+}
+
 pub struct RenderData {
     pub buffer: RenderBuffer,
     pub cursor_pos: Option<(usize, usize)>,
     pub changed: Arc<Notify>,
     pub force_redraw: bool,
+    pub ping_state: Option<PingState>, // set to None to disable pings
 }
-
 impl RenderData {
     pub fn clear(&mut self, width: usize, height: usize) {
         self.buffer.clear();
         self.buffer.resize(width, height);
         self.cursor_pos = None;
+    }
+
+    pub fn enable_pings(&mut self) {
+        self.ping_state = Some(PingState {
+            send_soon: false,
+            sent: None,
+            time: None,
+        });
+    }
+
+    pub fn disable_pings(&mut self) {
+        self.ping_state = None;
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -330,7 +330,6 @@ pub async fn ask_if_new_lobby(client: &mut Client) -> Result<bool, io::Error> {
             }
 
             if let Some(duration) = render_data.ping_state.as_ref().and_then(|s| s.time) {
-                println!("Render Ping!!!");
                 render_data
                     .buffer
                     .add_centered_text(22, &format!("Ping: {:>2}ms", duration.as_millis()));


### PR DESCRIPTION
Several issues currently:
- [ ] Hard to test. I have a temporary commit that I keep reverting.
- [ ] DSR key strokes are too visible in the bottom of the terminal. Maybe possible to hide with font color or some terminal mode? Just less frequent, currently every second?
- [ ] Ping times shown are too big. On localhost it shows 10ms or so when it should be instantaneous. When connecting with production server, it shows 100ms whereas `ping` on command line shows 50ms. Need to think about how exactly tcp sends data here...
- [ ] Web UI support
- [ ] Should be shown inside lobby view too