### PR TITLE
Handle websocket messages that contain multiple key presses

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -144,10 +144,10 @@ impl Receiver {
                         Ok(())
                     }
                     other => {
-                        return Err(io::Error::new(
+                        Err(io::Error::new(
                             ErrorKind::Other,
                             format!("unexpected websocket frame: {:?}", other),
-                        ));
+                        ))
                     }
                 }
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -143,12 +143,10 @@ impl Receiver {
                         recv_state.check_key_press_frequency()?;
                         Ok(())
                     }
-                    other => {
-                        Err(io::Error::new(
-                            ErrorKind::Other,
-                            format!("unexpected websocket frame: {:?}", other),
-                        ))
-                    }
+                    other => Err(io::Error::new(
+                        ErrorKind::Other,
+                        format!("unexpected websocket frame: {:?}", other),
+                    )),
                 }
             }
             Self::RawTcp {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -52,37 +52,47 @@ fn connection_closed_error() -> io::Error {
     io::Error::new(ErrorKind::ConnectionAborted, "connection closed")
 }
 
-fn check_key_press_frequency(key_press_times: &mut VecDeque<Instant>) -> Result<(), io::Error> {
-    key_press_times.push_back(Instant::now());
-    while !key_press_times.is_empty() && key_press_times[0].elapsed().as_secs_f32() > 1.0 {
-        key_press_times.pop_front();
-    }
-    if key_press_times.len() > 100 {
-        return Err(io::Error::new(
-            ErrorKind::ConnectionAborted,
-            "received more than 100 key presses / sec",
-        ));
-    }
-    Ok(())
+pub struct ReceiveState {
+    buffer: VecDeque<u8>,
+    key_press_times: VecDeque<Instant>,
+    last_recv: Instant,
 }
+impl ReceiveState {
+    fn on_bytes_received(&mut self) {
+        self.last_recv = Instant::now();
+    }
 
-fn get_timeout(last_recv: Instant) -> Duration {
-    let deadline = last_recv + Duration::from_secs(10 * 60);
-    deadline.saturating_duration_since(Instant::now())
+    fn get_timeout(&self) -> Duration {
+        let deadline = self.last_recv + Duration::from_secs(10 * 60);
+        deadline.saturating_duration_since(Instant::now())
+    }
+
+    fn check_key_press_frequency(&mut self) -> Result<(), io::Error> {
+        self.key_press_times.push_back(Instant::now());
+        while !self.key_press_times.is_empty()
+            && self.key_press_times[0].elapsed().as_secs_f32() > 1.0
+        {
+            self.key_press_times.pop_front();
+        }
+
+        if self.key_press_times.len() > 100 {
+            return Err(io::Error::new(
+                ErrorKind::ConnectionAborted,
+                "received more than 100 key presses / sec",
+            ));
+        }
+        Ok(())
+    }
 }
 
 pub enum Receiver {
     WebSocket {
         ws_reader: SplitStream<WebSocketStream<TcpStream>>,
-        key_press_times: VecDeque<Instant>,
-        last_recv: Instant,
+        recv_state: ReceiveState,
     },
     RawTcp {
         read_half: OwnedReadHalf,
-        buffer: [u8; 100], // keep small, receiving a single key press is O(recv buffer size)
-        buffer_size: usize,
-        key_press_times: VecDeque<Instant>,
-        last_recv: Instant,
+        recv_state: ReceiveState,
     },
     #[allow(dead_code)]
     Test(String),
@@ -90,103 +100,114 @@ pub enum Receiver {
 impl Receiver {
     pub async fn receive_key_press(&mut self) -> Result<KeyPress, io::Error> {
         match self {
-            Self::WebSocket {
-                ws_reader,
-                key_press_times,
-                last_recv,
-            } => {
-                loop {
-                    let item = timeout(get_timeout(*last_recv), ws_reader.next()).await?;
-                    if item.is_none() {
-                        return Err(connection_closed_error());
-                    }
-                    let item = item.unwrap();
-                    check_key_press_frequency(key_press_times)?;
-
-                    match item.map_err(convert_error)? {
-                        Message::Binary(bytes) => {
-                            *last_recv = Instant::now();
-                            match parse_key_press(&bytes) {
-                                // Websocket never splits a key press to multiple messages.
-                                // Also can't have multiple key presses inside the same message.
-                                Some((key, n)) if n == bytes.len() => {
-                                    return Ok(key);
-                                }
-                                Some(_) | None => {
-                                    return Err(io::Error::new(
-                                        ErrorKind::Other,
-                                        "received bad key press from websocket",
-                                    ))
-                                }
-                            }
-                        }
-                        Message::Close(_) => {
-                            return Err(connection_closed_error());
-                        }
-                        /*
-                        Pings can't make the connection stay open for more than 10min.
-                        That would cause confusion when people use different browsers and
-                        not all browsers send pings.
-
-                        Pings are counted as key presses, so that you will be disconnected
-                        if you spam the server with lots of pings.
-
-                        We don't have to send pongs, because tungstenite does it
-                        automatically.
-                        */
-                        Message::Ping(_) => {}
-                        other => {
-                            return Err(io::Error::new(
-                                ErrorKind::Other,
-                                format!("unexpected websocket frame: {:?}", other),
-                            ));
-                        }
-                    }
-                }
-            }
-
-            Self::RawTcp {
-                read_half,
-                buffer,
-                buffer_size,
-                key_press_times,
-                last_recv,
-            } => {
-                loop {
-                    match parse_key_press(&buffer[..*buffer_size]) {
-                        Some((key, bytes_used)) => {
-                            check_key_press_frequency(key_press_times)?;
-                            buffer[..*buffer_size].rotate_left(bytes_used);
-                            *buffer_size -= bytes_used;
-                            return Ok(key);
-                        }
-                        None => {
-                            // Receive more data
-                            let dest = &mut buffer[*buffer_size..];
-                            let n =
-                                timeout(get_timeout(*last_recv), read_half.read(dest)).await??;
-                            if n == 0 {
-                                return Err(connection_closed_error());
-                            }
-                            *buffer_size += n;
-                            *last_recv = Instant::now();
-                        }
-                    }
-                }
-            }
-
             Self::Test(string) => {
                 if string == "BLOCK" {
                     loop {
                         tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }
-                match parse_key_press(string.as_bytes()) {
+                return match parse_key_press(string.as_bytes()) {
                     Some((key, bytes_used)) => {
                         *string = string[bytes_used..].to_string();
                         Ok(key)
                     }
                     None => Err(connection_closed_error()),
+                };
+            }
+            _ => {}
+        }
+
+        loop {
+            let received_so_far: &[u8] = match self {
+                Self::Test(_) => panic!(),
+                Self::WebSocket { recv_state, .. } | Self::RawTcp { recv_state, .. } => {
+                    recv_state.buffer.make_contiguous();
+                    recv_state.buffer.as_slices().0
+                }
+            };
+
+            match parse_key_press(received_so_far) {
+                Some((key, bytes_used)) => {
+                    let recv_state = match self {
+                        Self::Test(_) => panic!(),
+                        Self::WebSocket { recv_state, .. } | Self::RawTcp { recv_state, .. } => {
+                            recv_state
+                        }
+                    };
+                    recv_state.check_key_press_frequency()?;
+                    recv_state.buffer.drain(0..bytes_used);
+                    return Ok(key);
+                }
+                None => {
+                    // Receive more data
+                    match self {
+                        Self::WebSocket {
+                            recv_state,
+                            ws_reader,
+                        } => {
+                            let item = timeout(recv_state.get_timeout(), ws_reader.next())
+                                .await? // error if timed out
+                                .ok_or_else(connection_closed_error)? // error if clean disconnect
+                                .map_err(convert_error)?; // error if receiving failed
+
+                            match item {
+                                Message::Binary(bytes) => {
+                                    if bytes.is_empty() {
+                                        return Err(io::Error::new(
+                                            ErrorKind::ConnectionAborted,
+                                            "received empty bytes from websocket message",
+                                        ));
+                                    }
+                                    for byte in bytes {
+                                        recv_state.buffer.push_back(byte);
+                                    }
+                                    recv_state.on_bytes_received();
+                                }
+                                Message::Close(_) => {
+                                    return Err(connection_closed_error());
+                                }
+                                /*
+                                Pings can't make the connection stay open for more than 10min.
+                                That would cause confusion when people use different browsers and
+                                not all browsers send pings.
+
+                                Pings are counted as key presses, so that you will be disconnected
+                                if you spam the server with lots of pings.
+
+                                We don't have to send pongs, because tungstenite does it
+                                automatically.
+                                */
+                                Message::Ping(_) => {
+                                    recv_state.check_key_press_frequency()?;
+                                }
+                                other => {
+                                    return Err(io::Error::new(
+                                        ErrorKind::Other,
+                                        format!("unexpected websocket frame: {:?}", other),
+                                    ));
+                                }
+                            }
+                        }
+                        Self::RawTcp {
+                            recv_state,
+                            read_half,
+                        } => {
+                            let mut buf = [0u8; 100];
+
+                            let n = timeout(recv_state.get_timeout(), read_half.read(&mut buf))
+                                .await??;
+                            if n == 0 {
+                                // a clean disconnect
+                                return Err(connection_closed_error());
+                            }
+                            recv_state.on_bytes_received();
+
+                            for byte in &buf[0..n] {
+                                recv_state.buffer.push_back(*byte);
+                            }
+                        }
+                        _ => panic!(),
+                    }
                 }
             }
         }
@@ -316,6 +337,12 @@ pub async fn initialize_connection(
         decrementer = Some(IpTracker::track(ip_tracker.clone(), source_ip, logger)?);
     }
 
+    let recv_state = ReceiveState {
+        buffer: VecDeque::new(),
+        key_press_times: VecDeque::new(),
+        last_recv: Instant::now(),
+    };
+
     if is_websocket {
         let config = WebSocketConfig {
             // Prevent various denial-of-service attacks that fill up server's memory.
@@ -351,18 +378,14 @@ pub async fn initialize_connection(
         sender = Sender::WebSocket { ws_writer };
         receiver = Receiver::WebSocket {
             ws_reader,
-            key_press_times: VecDeque::new(),
-            last_recv: Instant::now(),
+            recv_state,
         };
     } else {
         let (read_half, write_half) = socket.into_split();
         sender = Sender::RawTcp { write_half };
         receiver = Receiver::RawTcp {
             read_half,
-            buffer: [0u8; 100],
-            buffer_size: 0,
-            key_press_times: VecDeque::new(),
-            last_recv: Instant::now(),
+            recv_state,
         };
     }
 

--- a/web-ui/javascript.js
+++ b/web-ui/javascript.js
@@ -255,18 +255,15 @@ document.addEventListener("DOMContentLoaded", () => {
   }
   const ws = new WebSocket(wsUrl);
 
-  function sendKeyPress(text) {
+  function sendText(text) {
     const utf8 = new TextEncoder().encode(text);
-    if(ws.readyState === WebSocket.OPEN) {
+    if(ws.readyState === WebSocket.OPEN && utf8.length > 0) {
       ws.send(utf8);
     }
   }
 
   document.addEventListener("paste", event => {
-    const pastedText = event.clipboardData.getData("text/plain");
-    for (const character of pastedText.replace(/\n|\r|\x1b/g, "")) {
-      sendKeyPress(character);
-    }
+    sendText(event.clipboardData.getData("text/plain"));
   });
 
   document.onkeydown = (event) => {
@@ -276,19 +273,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (event.key.length === 1) {
-      sendKeyPress(event.key);
+      sendText(event.key);
     } else if (event.key === "ArrowUp") {
-      sendKeyPress("\x1b[A");
+      sendText("\x1b[A");
     } else if (event.key === "ArrowDown") {
-      sendKeyPress("\x1b[B");
+      sendText("\x1b[B");
     } else if (event.key === "ArrowRight") {
-      sendKeyPress("\x1b[C");
+      sendText("\x1b[C");
     } else if (event.key === "ArrowLeft") {
-      sendKeyPress("\x1b[D");
+      sendText("\x1b[D");
     } else if (event.key === "Backspace") {
-      sendKeyPress("\x7f");
+      sendText("\x7f");
     } else if (event.key === "Enter") {
-      sendKeyPress("\r");
+      sendText("\r");
     } else {
       console.log("Unrecognized key:", event.key);
       return;

--- a/wsclient.py
+++ b/wsclient.py
@@ -14,49 +14,10 @@ import aiofiles
 import websockets
 
 
-# TODO: Do this in catris, so that the code here would be shorter
-async def send_full_characters_and_ansi_codes(send_queue, ws):
-    while send_queue:
-        count = 0
-        if send_queue[0] == 0x1B:
-            # ansi code, it will end with some uppercase letter
-            for index, char in send_queue:
-                if char in b"ABCDEFGHIJKLMNOPQRSTUVWXYZ":
-                    count = index + 1
-                    break
-            else:
-                # part of ansi code still missing
-                return
-        elif send_queue[0] < 128:
-            # ascii character
-            count = 1
-        elif send_queue[0] >> 5 == 0b110:
-            # utf-8 two-byte character
-            count = 2
-        elif send_queue[0] >> 4 == 0b1110:
-            # utf-8 three-byte character
-            count = 3
-        elif send_queue[0] >> 3 == 0b11110:
-            # utf-8 four-byte character
-            count = 4
-        else:
-            # invalid input
-            send_queue = send_queue[1:]
-            break
-
-        if len(send_queue) < count:
-            return
-
-        await ws.send(send_queue[:count])
-        del send_queue[:count]
-
-
 async def stdin_to_websocket(ws):
     async with aiofiles.open("/dev/stdin", "rb") as file:
-        send_queue = bytearray()
         while True:
-            send_queue += await file.read1(1024)
-            await send_full_characters_and_ansi_codes(send_queue, ws)
+            await ws.send(await file.read1(1024))
 
 
 async def websocket_to_stdout(ws):


### PR DESCRIPTION
Simplifies the client sides of websockets. Now there's two of them, so their simplicity matters more than the rust program.