### PR TITLE
Fix a bug that caused a crash in production

### DIFF
--- a/src/game_logic/blocks.rs
+++ b/src/game_logic/blocks.rs
@@ -558,7 +558,7 @@ impl FallingBlock {
     }
 
     pub fn set_player_coords(&mut self, coords: &[PlayerPoint], new_center: PlayerPoint) {
-        assert!(coords.len() != 0);  // instead of making empty block, just give a new block to the player
+        assert!(coords.len() != 0); // instead of making empty block, just give a new block to the player
         self.center = new_center;
         let (cx, cy) = new_center;
         self.relative_coords = coords

--- a/src/game_logic/blocks.rs
+++ b/src/game_logic/blocks.rs
@@ -557,7 +557,10 @@ impl FallingBlock {
         self.add_center(&self.relative_coords)
     }
 
+    // Make sure to never set the coords to empty.
+    // An empty block doesn't make sense, and players should just get a new block instead.
     pub fn set_player_coords(&mut self, coords: &[PlayerPoint], new_center: PlayerPoint) {
+        assert!(coords.len() != 0);
         self.center = new_center;
         let (cx, cy) = new_center;
         self.relative_coords = coords

--- a/src/game_logic/blocks.rs
+++ b/src/game_logic/blocks.rs
@@ -557,8 +557,6 @@ impl FallingBlock {
         self.add_center(&self.relative_coords)
     }
 
-    // Make sure to never set the coords to empty.
-    // An empty block doesn't make sense, and players should just get a new block instead.
     pub fn set_player_coords(&mut self, coords: &[PlayerPoint], new_center: PlayerPoint) {
         assert!(coords.len() != 0);
         self.center = new_center;


### PR DESCRIPTION
In a corner case with a player leaving and their entire block getting wiped away, it was possible to set the moving block coords to empty for a remaining player, and that caused the game to panic. Systemd restarted the game after it crashed.