### PR TITLE
Add logging to show joining/leaving a game

### DIFF
--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -104,15 +104,16 @@ impl Lobby {
             .iter()
             .find(|info| info.client_id == client_id)
             .unwrap();
-        client_info.logger.log(&format!("Joining game: {:?}", mode));
 
         let wrapper = if let Some(wrapper) = self.game_wrappers.get(&mode) {
             if !wrapper.game.lock().unwrap().add_player(client_info) {
                 return None;
             }
+            client_info.logger.log(&format!("Joining existing game: {:?}", mode));
             wrapper.mark_changed();
             wrapper.clone()
         } else {
+            client_info.logger.log(&format!("Creating and joining game: {:?}", mode));
             let mut game = Game::new(mode);
             let ok = game.add_player(client_info);
             assert!(ok);

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -104,6 +104,7 @@ impl Lobby {
             .iter()
             .find(|info| info.client_id == client_id)
             .unwrap();
+        client_info.logger.log(&format!("Joining game: {:?}", mode));
 
         let wrapper = if let Some(wrapper) = self.game_wrappers.get(&mode) {
             if !wrapper.game.lock().unwrap().add_player(client_info) {
@@ -126,6 +127,9 @@ impl Lobby {
     }
 
     pub fn leave_game(&mut self, client_id: u64, mode: Mode) {
+        let logger = ClientLogger { client_id };
+        logger.log(&format!("Leaving game: {:?}", mode));
+
         let last_player_removed = if let Some(wrapper) = self.game_wrappers.get(&mode) {
             let mut game = wrapper.game.lock().unwrap();
             game.remove_player_if_exists(client_id);

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -109,11 +109,15 @@ impl Lobby {
             if !wrapper.game.lock().unwrap().add_player(client_info) {
                 return None;
             }
-            client_info.logger.log(&format!("Joining existing game: {:?}", mode));
+            client_info
+                .logger
+                .log(&format!("Joining existing game: {:?}", mode));
             wrapper.mark_changed();
             wrapper.clone()
         } else {
-            client_info.logger.log(&format!("Creating and joining game: {:?}", mode));
+            client_info
+                .logger
+                .log(&format!("Creating and joining game: {:?}", mode));
             let mut game = Game::new(mode);
             let ok = game.add_player(client_info);
             assert!(ok);

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -126,7 +126,7 @@ impl Lobby {
         Some(wrapper)
     }
 
-    pub fn leave_game(&mut self, client_id: u64, mode: Mode) {
+    fn leave_game(&mut self, client_id: u64, mode: Mode) {
         let logger = ClientLogger { client_id };
         logger.log(&format!("Leaving game: {:?}", mode));
 


### PR DESCRIPTION
When looking at the logs for #292, I noticed I could see the players joining and leaving the lobby, but not individual games.