### PR TITLE
Delete ClientLogger

### DIFF
--- a/src/game_logic/test.rs
+++ b/src/game_logic/test.rs
@@ -1,4 +1,3 @@
-use crate::client::ClientLogger;
 use crate::escapes::Color;
 use crate::escapes::KeyPress;
 use crate::escapes::TerminalType;
@@ -115,9 +114,6 @@ fn create_game(mode: Mode, player_count: usize, shape: Shape) -> Game {
             name: format!("Player {}", i),
             client_id: i as u64,
             color: Color::RED_FOREGROUND.fg,
-            logger: ClientLogger {
-                client_id: i as u64,
-            },
         });
     }
     game
@@ -743,9 +739,6 @@ fn create_ring_game_with_drills() -> Game {
             name: format!("Player {}", i),
             client_id: i as u64,
             color: Color::RED_FOREGROUND.fg,
-            logger: ClientLogger {
-                client_id: i as u64,
-            },
         });
     }
     game
@@ -838,9 +831,6 @@ fn test_displaying_landed_drills() {
             name: format!("Player {}", i),
             client_id: i as u64,
             color: Color::RED_FOREGROUND.fg,
-            logger: ClientLogger {
-                client_id: i as u64,
-            },
         });
     }
 

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -1,5 +1,4 @@
-use crate::client;
-use crate::client::ClientLogger;
+use crate::client::log_for_client;
 use crate::game_logic::game::Game;
 use crate::game_logic::game::Mode;
 use crate::game_wrapper;
@@ -14,7 +13,6 @@ use weak_table::WeakValueHashMap;
 
 pub struct ClientInfo {
     pub client_id: u64,
-    pub logger: ClientLogger,
     pub name: String,
     pub color: u8,
 }
@@ -64,21 +62,24 @@ impl Lobby {
         self.changed_sender.send(()).unwrap();
     }
 
-    pub fn add_client(&mut self, logger: client::ClientLogger, name: &str) {
+    pub fn add_client(&mut self, client_id: u64, name: &str) {
+        log_for_client(
+            client_id,
+            &format!(
+                "Joining lobby with {} existing clients: {}",
+                self.clients.len(),
+                self.id
+            ),
+        );
+
         assert!(!self.lobby_is_full());
-        logger.log(&format!(
-            "Joining lobby with {} existing clients: {}",
-            self.clients.len(),
-            self.id
-        ));
         let used_colors: Vec<u8> = self.clients.iter().map(|c| c.color).collect();
         let unused_color = *ALL_COLORS
             .iter()
             .find(|color| !used_colors.contains(*color))
             .unwrap();
         self.clients.push(ClientInfo {
-            client_id: logger.client_id,
-            logger,
+            client_id,
             name: name.to_string(),
             color: unused_color,
         });
@@ -86,14 +87,12 @@ impl Lobby {
     }
 
     pub fn remove_client(&mut self, client_id: u64) {
+        log_for_client(client_id, &format!("Leaving lobby: {}", self.id));
         let i = self
             .clients
             .iter()
             .position(|c| c.client_id == client_id)
             .unwrap();
-        self.clients[i]
-            .logger
-            .log(&format!("Leaving lobby: {}", self.id));
         self.clients.remove(i);
         self.mark_changed();
     }
@@ -109,15 +108,11 @@ impl Lobby {
             if !wrapper.game.lock().unwrap().add_player(client_info) {
                 return None;
             }
-            client_info
-                .logger
-                .log(&format!("Joining existing game: {:?}", mode));
+            log_for_client(client_id, &format!("Joining existing game: {:?}", mode));
             wrapper.mark_changed();
             wrapper.clone()
         } else {
-            client_info
-                .logger
-                .log(&format!("Creating and joining game: {:?}", mode));
+            log_for_client(client_id, &format!("Creating and joining game: {:?}", mode));
             let mut game = Game::new(mode);
             let ok = game.add_player(client_info);
             assert!(ok);
@@ -132,9 +127,7 @@ impl Lobby {
     }
 
     fn leave_game(&mut self, client_id: u64, mode: Mode) {
-        let logger = ClientLogger { client_id };
-        logger.log(&format!("Leaving game: {:?}", mode));
-
+        log_for_client(client_id, &format!("Leaving game: {:?}", mode));
         let last_player_removed = if let Some(wrapper) = self.game_wrappers.get(&mode) {
             let mut game = wrapper.game.lock().unwrap();
             game.remove_player_if_exists(client_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 #[macro_use(lazy_static)]
 extern crate lazy_static;
 
+use crate::client::log_for_client;
 use crate::client::Client;
-use crate::client::ClientLogger;
 use crate::connection::get_websocket_proxy_ip;
 use crate::connection::initialize_connection;
 use crate::connection::Receiver;
@@ -43,9 +43,10 @@ async fn handle_receiving(
     used_names: Arc<Mutex<HashSet<String>>>,
 ) -> Result<(), io::Error> {
     views::ask_name(&mut client, used_names).await?;
-    client
-        .logger()
-        .log(&format!("Name asking done: {}", client.get_name().unwrap()));
+    log_for_client(
+        client.id,
+        &format!("Name asking done: {}", client.get_name().unwrap()),
+    );
 
     let want_new_lobby = views::ask_if_new_lobby(&mut client).await?;
     if want_new_lobby {
@@ -165,7 +166,7 @@ pub async fn detect_terminal_type(
 }
 
 async fn handle_connection_until_error(
-    logger: ClientLogger,
+    client_id: u64,
     socket: TcpStream,
     source_ip: IpAddr,
     lobbies: lobby::Lobbies,
@@ -174,16 +175,19 @@ async fn handle_connection_until_error(
     is_websocket: bool,
 ) -> Result<(), io::Error> {
     let (mut sender, mut receiver, _decrementer) =
-        initialize_connection(ip_tracker, logger, socket, source_ip, is_websocket).await?;
+        initialize_connection(ip_tracker, client_id, socket, source_ip, is_websocket).await?;
 
     let terminal_type = timeout(
         Duration::from_secs(20),
         detect_terminal_type(&mut sender, &mut receiver),
     )
     .await??;
-    logger.log(&format!("Terminal type detected: {:?}", terminal_type));
+    log_for_client(
+        client_id,
+        &format!("Terminal type detected: {:?}", terminal_type),
+    );
 
-    let client = Client::new(logger.client_id, receiver, terminal_type);
+    let client = Client::new(client_id, receiver, terminal_type);
     let render_data = client.render_data.clone();
 
     let result = tokio::select! {
@@ -215,15 +219,14 @@ async fn handle_connection(
     // not sure what ordering to use, so choosing the one with most niceness guarantees
     let client_id = CLIENT_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
 
-    let logger = ClientLogger { client_id };
     if is_websocket {
-        logger.log("New websocket connection");
+        log_for_client(client_id, "New websocket connection");
     } else {
-        logger.log("New raw TCP connection");
+        log_for_client(client_id, "New raw TCP connection");
     }
 
     let error = handle_connection_until_error(
-        logger,
+        client_id,
         socket,
         source_ip,
         lobbies,
@@ -233,7 +236,7 @@ async fn handle_connection(
     )
     .await
     .unwrap_err();
-    logger.log(&format!("Disconnected: {}", error));
+    log_for_client(client_id, &format!("Disconnected: {}", error));
 }
 
 #[tokio::main]

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,3 +1,4 @@
+use crate::client::log_for_client;
 use crate::client::Client;
 use crate::escapes::Color;
 use crate::escapes::KeyPress;
@@ -296,9 +297,7 @@ pub async fn ask_if_new_lobby(client: &mut Client) -> Result<bool, io::Error> {
         Ok(lines) => lines,
         Err(e) if e.kind() == ErrorKind::NotFound => vec![],
         Err(e) => {
-            client
-                .logger()
-                .log(&format!("reading motd file failed: {:?}", e));
+            log_for_client(client.id, &format!("reading motd file failed: {:?}", e));
             vec![]
         }
     };


### PR DESCRIPTION
Simplifies the code a bit: we can just pass the client ID around and call a function that takes the ID when we need to log. Does not affect behaviour.